### PR TITLE
fix: poll cpu at higher frequency to prevent mqtt keep alive failure

### DIFF
--- a/src/collectd.conf
+++ b/src/collectd.conf
@@ -79,7 +79,12 @@ LoadPlugin syslog
 # Specify what features to activate.                                         #
 ##############################################################################
 
-LoadPlugin cpu
+# Keep at least 1 metric within the mqtt keep alive interval of 60 seconds
+# to prevent the mqtt connection from failing and dopping metrics
+<LoadPlugin cpu>
+	Interval 60
+</LoadPlugin>
+
 <LoadPlugin df>
 	Interval 3600
 </LoadPlugin>


### PR DESCRIPTION
Decrease interval of cpu metric to 60 seconds to prevent write failures due to the MQTT connection dropping out, and only be reestablished when the next poll is executed.

This is a temporary workaround until a better solution is found.