### PR TITLE
fix: remove metric for disk usage on resolv.conf

### DIFF
--- a/src/collectd.conf
+++ b/src/collectd.conf
@@ -138,7 +138,6 @@ LoadPlugin unixsock
 	
 	# Ignore docker mounted volumes
 	#Device "/dev/disk/by-label/data-volume"
-	MountPoint "/etc/resolv.conf"
 	MountPoint "/etc/hostname"
 	MountPoint "/etc/hosts"
 


### PR DESCRIPTION
Monitoring the /etc/resolv.conf mount point results in creating a measurement with an unsupported character `.`. Since this metric provides little value, it has been removed from the config